### PR TITLE
Compatibility with RustCrypto

### DIFF
--- a/balloon.go
+++ b/balloon.go
@@ -126,7 +126,7 @@ func (b *Instance) Mix(h hash.Hash, salt []byte, sCost, tCost uint64) {
 				h.Write(salt)
 				h.Write(idxBlock)
 				otherBytes := h.Sum(nil)
-				otherWords := make([]big.Word, h.Size() / (bits.UintSize / 8))
+				otherWords := make([]big.Word, h.Size()/(bits.UintSize/8))
 
 				for byte, word := 0, 0; byte < len(otherBytes); byte, word = byte+bits.UintSize/8, word+1 {
 					if bits.UintSize == 64 {

--- a/balloon_test.go
+++ b/balloon_test.go
@@ -9,7 +9,10 @@ package balloon
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/hex"
+	"reflect"
 	"testing"
 )
 
@@ -28,5 +31,67 @@ func BenchmarkBalloonM(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		BalloonM(sha512.New, ps[:8], ps[8:], 16, 16, 4)
+	}
+}
+
+func TestVectors(t *testing.T) {
+	type test_vector struct {
+		password []byte
+		salt []byte
+		s_cost uint64
+		t_cost uint64
+		output string
+	}
+
+	test_vectors := []test_vector{
+		{
+			password: []byte("hunter42"),
+			salt: []byte("examplesalt"),
+			s_cost: 1024,
+			t_cost: 3,
+			output: "716043dff777b44aa7b88dcbab12c078abecfac9d289c5b5195967aa63440dfb",
+		},
+		{
+			password: []byte(""),
+			salt: []byte("salt"),
+			s_cost: 3,
+			t_cost: 3,
+			output: "5f02f8206f9cd212485c6bdf85527b698956701ad0852106f94b94ee94577378",
+		},
+		{
+			password: []byte("password"),
+			salt: []byte(""),
+			s_cost: 3,
+			t_cost: 3,
+			output: "20aa99d7fe3f4df4bd98c655c5480ec98b143107a331fd491deda885c4d6a6cc",
+		},
+		{
+			password: []byte("\000"),
+			salt: []byte("\000"),
+			s_cost: 3,
+			t_cost: 3,
+			output: "4fc7e302ffa29ae0eac31166cee7a552d1d71135f4e0da66486fb68a749b73a4",
+		},
+		{
+			password: []byte("password"),
+			salt: []byte("salt"),
+			s_cost: 1,
+			t_cost: 1,
+			output: "eefda4a8a75b461fa389c1dcfaf3e9dfacbc26f81f22e6f280d15cc18c417545",
+		},
+	}
+
+	for _, vector := range test_vectors {
+		output := Balloon(sha256.New(), vector.password, vector.salt, vector.s_cost, vector.t_cost)
+		data, err := hex.DecodeString(vector.output)
+
+		if err != nil {
+			panic(err)
+		}
+
+		if !reflect.DeepEqual(output, data) {
+			t.Log("Expected: ", vector.output, " Output: ", hex.EncodeToString(output))
+			t.Fail()
+		}
 	}
 }

--- a/balloon_test.go
+++ b/balloon_test.go
@@ -34,7 +34,7 @@ func BenchmarkBalloonM(b *testing.B) {
 	}
 }
 
-func TestVectors(t *testing.T) {
+func TestBalloonVectors(t *testing.T) {
 	type test_vector struct {
 		password []byte
 		salt []byte
@@ -83,6 +83,98 @@ func TestVectors(t *testing.T) {
 
 	for _, vector := range test_vectors {
 		output := Balloon(sha256.New(), vector.password, vector.salt, vector.s_cost, vector.t_cost)
+		data, err := hex.DecodeString(vector.output)
+
+		if err != nil {
+			panic(err)
+		}
+
+		if !reflect.DeepEqual(output, data) {
+			t.Log("Expected: ", vector.output, " Output: ", hex.EncodeToString(output))
+			t.Fail()
+		}
+	}
+}
+
+func TestBalloonMVectors(t *testing.T) {
+	type test_vector struct {
+		password []byte
+		salt []byte
+		s_cost uint64
+		t_cost uint64
+		p_cost uint64
+		output string
+	}
+
+	test_vectors := []test_vector{
+		{
+			password: []byte("hunter42"),
+			salt: []byte("examplesalt"),
+			s_cost: 1024,
+			t_cost: 3,
+			p_cost: 4,
+			output: "1832bd8e5cbeba1cb174a13838095e7e66508e9bf04c40178990adbc8ba9eb6f",
+		},
+		{
+			password: []byte(""),
+			salt: []byte("salt"),
+			s_cost: 3,
+			t_cost: 3,
+			p_cost: 2,
+			output: "f8767fe04059cef67b4427cda99bf8bcdd983959dbd399a5e63ea04523716c23",
+		},
+		{
+			password: []byte("password"),
+			salt: []byte(""),
+			s_cost: 3,
+			t_cost: 3,
+			p_cost: 3,
+			output: "bcad257eff3d1090b50276514857e60db5d0ec484129013ef3c88f7d36e438d6",
+		},
+		{
+			password: []byte("password"),
+			salt: []byte(""),
+			s_cost: 3,
+			t_cost: 3,
+			p_cost: 1,
+			output: "498344ee9d31baf82cc93ebb3874fe0b76e164302c1cefa1b63a90a69afb9b4d",
+		},
+		{
+			password: []byte("\000"),
+			salt: []byte("\000"),
+			s_cost: 3,
+			t_cost: 3,
+			p_cost: 4,
+			output: "8a665611e40710ba1fd78c181549c750f17c12e423c11930ce997f04c7153e0c",
+		},
+		{
+			password: []byte("\000"),
+			salt: []byte("\000"),
+			s_cost: 3,
+			t_cost: 3,
+			p_cost: 1,
+			output: "d9e33c683451b21fb3720afbd78bf12518c1d4401fa39f054b052a145c968bb1",
+		},
+		{
+			password: []byte("password"),
+			salt: []byte("salt"),
+			s_cost: 1,
+			t_cost: 1,
+			p_cost: 16,
+			output: "a67b383bb88a282aef595d98697f90820adf64582a4b3627c76b7da3d8bae915",
+		},
+		{
+			password: []byte("password"),
+			salt: []byte("salt"),
+			s_cost: 1,
+			t_cost: 1,
+			p_cost: 1,
+			output: "97a11df9382a788c781929831d409d3599e0b67ab452ef834718114efdcd1c6d",
+		},
+	}
+
+	for _, vector := range test_vectors {
+		output := BalloonM(sha256.New, vector.password, vector.salt, vector.s_cost, vector.t_cost, vector.p_cost)
 		data, err := hex.DecodeString(vector.output)
 
 		if err != nil {

--- a/balloon_test.go
+++ b/balloon_test.go
@@ -35,54 +35,54 @@ func BenchmarkBalloonM(b *testing.B) {
 }
 
 func TestBalloonVectors(t *testing.T) {
-	type test_vector struct {
+	type testVector struct {
 		password []byte
-		salt []byte
-		s_cost uint64
-		t_cost uint64
-		output string
+		salt     []byte
+		sCost    uint64
+		tCost    uint64
+		output   string
 	}
 
-	test_vectors := []test_vector{
+	testVectors := []testVector{
 		{
 			password: []byte("hunter42"),
-			salt: []byte("examplesalt"),
-			s_cost: 1024,
-			t_cost: 3,
-			output: "716043dff777b44aa7b88dcbab12c078abecfac9d289c5b5195967aa63440dfb",
+			salt:     []byte("examplesalt"),
+			sCost:    1024,
+			tCost:    3,
+			output:   "716043dff777b44aa7b88dcbab12c078abecfac9d289c5b5195967aa63440dfb",
 		},
 		{
 			password: []byte(""),
-			salt: []byte("salt"),
-			s_cost: 3,
-			t_cost: 3,
-			output: "5f02f8206f9cd212485c6bdf85527b698956701ad0852106f94b94ee94577378",
+			salt:     []byte("salt"),
+			sCost:    3,
+			tCost:    3,
+			output:   "5f02f8206f9cd212485c6bdf85527b698956701ad0852106f94b94ee94577378",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte(""),
-			s_cost: 3,
-			t_cost: 3,
-			output: "20aa99d7fe3f4df4bd98c655c5480ec98b143107a331fd491deda885c4d6a6cc",
+			salt:     []byte(""),
+			sCost:    3,
+			tCost:    3,
+			output:   "20aa99d7fe3f4df4bd98c655c5480ec98b143107a331fd491deda885c4d6a6cc",
 		},
 		{
 			password: []byte("\000"),
-			salt: []byte("\000"),
-			s_cost: 3,
-			t_cost: 3,
-			output: "4fc7e302ffa29ae0eac31166cee7a552d1d71135f4e0da66486fb68a749b73a4",
+			salt:     []byte("\000"),
+			sCost:    3,
+			tCost:    3,
+			output:   "4fc7e302ffa29ae0eac31166cee7a552d1d71135f4e0da66486fb68a749b73a4",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte("salt"),
-			s_cost: 1,
-			t_cost: 1,
-			output: "eefda4a8a75b461fa389c1dcfaf3e9dfacbc26f81f22e6f280d15cc18c417545",
+			salt:     []byte("salt"),
+			sCost:    1,
+			tCost:    1,
+			output:   "eefda4a8a75b461fa389c1dcfaf3e9dfacbc26f81f22e6f280d15cc18c417545",
 		},
 	}
 
-	for _, vector := range test_vectors {
-		output := Balloon(sha256.New(), vector.password, vector.salt, vector.s_cost, vector.t_cost)
+	for _, vector := range testVectors {
+		output := Balloon(sha256.New(), vector.password, vector.salt, vector.sCost, vector.tCost)
 		data, err := hex.DecodeString(vector.output)
 
 		if err != nil {
@@ -97,84 +97,84 @@ func TestBalloonVectors(t *testing.T) {
 }
 
 func TestBalloonMVectors(t *testing.T) {
-	type test_vector struct {
+	type testVector struct {
 		password []byte
-		salt []byte
-		s_cost uint64
-		t_cost uint64
-		p_cost uint64
-		output string
+		salt     []byte
+		sCost    uint64
+		tCost    uint64
+		pCost    uint64
+		output   string
 	}
 
-	test_vectors := []test_vector{
+	testVectors := []testVector{
 		{
 			password: []byte("hunter42"),
-			salt: []byte("examplesalt"),
-			s_cost: 1024,
-			t_cost: 3,
-			p_cost: 4,
-			output: "1832bd8e5cbeba1cb174a13838095e7e66508e9bf04c40178990adbc8ba9eb6f",
+			salt:     []byte("examplesalt"),
+			sCost:    1024,
+			tCost:    3,
+			pCost:    4,
+			output:   "1832bd8e5cbeba1cb174a13838095e7e66508e9bf04c40178990adbc8ba9eb6f",
 		},
 		{
 			password: []byte(""),
-			salt: []byte("salt"),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 2,
-			output: "f8767fe04059cef67b4427cda99bf8bcdd983959dbd399a5e63ea04523716c23",
+			salt:     []byte("salt"),
+			sCost:    3,
+			tCost:    3,
+			pCost:    2,
+			output:   "f8767fe04059cef67b4427cda99bf8bcdd983959dbd399a5e63ea04523716c23",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte(""),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 3,
-			output: "bcad257eff3d1090b50276514857e60db5d0ec484129013ef3c88f7d36e438d6",
+			salt:     []byte(""),
+			sCost:    3,
+			tCost:    3,
+			pCost:    3,
+			output:   "bcad257eff3d1090b50276514857e60db5d0ec484129013ef3c88f7d36e438d6",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte(""),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 1,
-			output: "498344ee9d31baf82cc93ebb3874fe0b76e164302c1cefa1b63a90a69afb9b4d",
+			salt:     []byte(""),
+			sCost:    3,
+			tCost:    3,
+			pCost:    1,
+			output:   "498344ee9d31baf82cc93ebb3874fe0b76e164302c1cefa1b63a90a69afb9b4d",
 		},
 		{
 			password: []byte("\000"),
-			salt: []byte("\000"),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 4,
-			output: "8a665611e40710ba1fd78c181549c750f17c12e423c11930ce997f04c7153e0c",
+			salt:     []byte("\000"),
+			sCost:    3,
+			tCost:    3,
+			pCost:    4,
+			output:   "8a665611e40710ba1fd78c181549c750f17c12e423c11930ce997f04c7153e0c",
 		},
 		{
 			password: []byte("\000"),
-			salt: []byte("\000"),
-			s_cost: 3,
-			t_cost: 3,
-			p_cost: 1,
-			output: "d9e33c683451b21fb3720afbd78bf12518c1d4401fa39f054b052a145c968bb1",
+			salt:     []byte("\000"),
+			sCost:    3,
+			tCost:    3,
+			pCost:    1,
+			output:   "d9e33c683451b21fb3720afbd78bf12518c1d4401fa39f054b052a145c968bb1",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte("salt"),
-			s_cost: 1,
-			t_cost: 1,
-			p_cost: 16,
-			output: "a67b383bb88a282aef595d98697f90820adf64582a4b3627c76b7da3d8bae915",
+			salt:     []byte("salt"),
+			sCost:    1,
+			tCost:    1,
+			pCost:    16,
+			output:   "a67b383bb88a282aef595d98697f90820adf64582a4b3627c76b7da3d8bae915",
 		},
 		{
 			password: []byte("password"),
-			salt: []byte("salt"),
-			s_cost: 1,
-			t_cost: 1,
-			p_cost: 1,
-			output: "97a11df9382a788c781929831d409d3599e0b67ab452ef834718114efdcd1c6d",
+			salt:     []byte("salt"),
+			sCost:    1,
+			tCost:    1,
+			pCost:    1,
+			output:   "97a11df9382a788c781929831d409d3599e0b67ab452ef834718114efdcd1c6d",
 		},
 	}
 
-	for _, vector := range test_vectors {
-		output := BalloonM(sha256.New, vector.password, vector.salt, vector.s_cost, vector.t_cost, vector.p_cost)
+	for _, vector := range testVectors {
+		output := BalloonM(sha256.New, vector.password, vector.salt, vector.sCost, vector.tCost, vector.pCost)
 		data, err := hex.DecodeString(vector.output)
 
 		if err != nil {


### PR DESCRIPTION
Hi!

I'm currently working on an implementation of the Balloon hashing algorithm for the RustCrypto organization: RustCrypto/password-hashes#232. In an effort to make this viable, I am seeking to provide compatibility between different implementations.

Only two changes are required to provide compatibility:
- Change encoding of values to little-endian as is done in the prototype implementation
- The `ints_to_block` function was interpreted as hashing these values and produce a "block" of bytes; the prototype implementation uses some sort of encryption here, I merely replaced it with the hash already used

Any input is welcome! I added test-vectors to assure compatibility. I am willing to contribute a CI setup, just say the word!
I have never programmed in Go before!

Another library I provided compatibility for: nachonavarro/balloon-hashing#2

Addresses #1.